### PR TITLE
feat: add a use cases template for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/use-case.md
+++ b/.github/ISSUE_TEMPLATE/use-case.md
@@ -1,0 +1,44 @@
+---
+name: Use Case
+about: Use this template to propose an LWS use case.
+title: "[UC] <<brief description of use case>>"
+labels: triage, usecase
+assignees: ''
+
+---
+
+**As a [primary actor],**
+**I want [an action or feature],**
+**So that [a reason or benefit].**
+
+## Preconditions:
+
+*What preconditions do we expect there to be fulfilled prior to this use case being triggered?*
+
+## Trigger:
+
+*What triggers this use case?*
+
+## Actors:
+
+*Describe the primary actor, and any other relevant actors involved in this use case*
+
+## Distinction:
+
+*What is the challenge in realizing this use case? What distinguishes it from other, similar use cases?*
+
+## Scenario:
+
+*A more detailed happy-case scenario where this use case would be relevant*
+
+## Alternative case(s):
+
+*What alternative flows do we think a system must cover for this use case?*
+
+## Acceptance Criteria:
+
+*When do we consider this use case to be sufficiently covered by the specification, what limitations do we consider acceptable?*
+
+## References:
+
+*Any relevant references, for example to practical examples of this use case or possible solutions (in other domains)*

--- a/.github/ISSUE_TEMPLATE/use-case.md
+++ b/.github/ISSUE_TEMPLATE/use-case.md
@@ -13,7 +13,7 @@ assignees: ''
 
 ## Preconditions:
 
-*What preconditions do we expect there to be fulfilled prior to this use case being triggered?*
+*What conditions must be in place or assumed before this use case can begin?*
 
 ## Trigger:
 
@@ -25,20 +25,20 @@ assignees: ''
 
 ## Distinction:
 
-*What is the challenge in realizing this use case? What distinguishes it from other, similar use cases?*
+*What unique challenges or distinguishing factors (like technical issues, user experience needs, workflow integration, etc.) are associated with this use case?*
 
 ## Scenario:
 
-*A more detailed happy-case scenario where this use case would be relevant*
+*Describe an ideal or happy-case scenario where this use case would play out as intended.*
 
 ## Alternative case(s):
 
-*What alternative flows do we think a system must cover for this use case?*
+*What alternative flows or variations should the system handle for this use case?*
 
 ## Acceptance Criteria:
 
-*When do we consider this use case to be sufficiently covered by the specification, what limitations do we consider acceptable?*
+*What conditions or criteria must be met for this use case to be considered successfully handled? What limitations are acceptable?*
 
 ## References:
 
-*Any relevant references, for example to practical examples of this use case or possible solutions (in other domains)*
+*List any relevant resources or examples that could inform this use case, possibly from other domains or solutions.*

--- a/.github/ISSUE_TEMPLATE/use-case.md
+++ b/.github/ISSUE_TEMPLATE/use-case.md
@@ -17,7 +17,7 @@ assignees: ''
 
 ## Trigger:
 
-*What triggers this use case?*
+*What (user or system) event or action initiates this use case?*
 
 ## Actors:
 

--- a/.github/ISSUE_TEMPLATE/use-case.md
+++ b/.github/ISSUE_TEMPLATE/use-case.md
@@ -34,6 +34,9 @@ labels: triage, usecase
 
 *What alternative flows or variations should the system handle for this use case?*
 
+## Error scenario:
+
+*What unexpected issues or errors might arise, and how should the system handle them?*
 ## Acceptance Criteria:
 
 *What conditions or criteria must be met for this use case to be considered successfully handled? What limitations are acceptable?*

--- a/.github/ISSUE_TEMPLATE/use-case.md
+++ b/.github/ISSUE_TEMPLATE/use-case.md
@@ -3,7 +3,6 @@ name: Use Case
 about: Use this template to propose an LWS use case.
 title: "[UC] <<brief description of use case>>"
 labels: triage, usecase
-assignees: ''
 
 ---
 


### PR DESCRIPTION
This is a proposal for a Github issues template for use cases for the LWS WG, all feedback is welcome.


The template was loosely inspired on
[VC Use Cases](https://www.w3.org/TR/vc-use-cases/)
[DID Use Cases](https://www.w3.org/TR/did-use-cases/)
[WOT Use Cases](https://www.w3.org/TR/wot-usecases/#digital-twin-2)