### PR TITLE
Build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,30 @@
+# How to build this spec
+
+This repository uses the [ReSpec toolchain](https://respec.org/docs/). Please find below a quick getting started cheatsheet using the [command line](https://respec.org/docs/#using-command-line) tools.
+
+Setup `respec` for multiple use:
+```
+$ npm install --global respec
+```
+Update your environment with the following variables:
+```
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+export PUPPETEER_EXECUTABLE_PATH="/usr/bin/google-chrome"
+# replace "/usr/bin/google-chrome" with path to Chrome executable on your system.
+# On MacOS, it's generally:
+# "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+```
+This spec uses the `data-include` attribute. For `respec` to work locally, the content MUST be served by a web server. One easy way to achive that is to run one from the project directory:
+```
+# Install a local HTTP server if not already installed (one time)
+$ npm install -g http-server
+
+# Start the server in your project directory
+$ http-server
+```
+
+Note that the server starts on port 8080. Now you can run `respec` to generate the spec [`index.html`](http://localhost:8080/index.html) in the project root and test changes.
+```
+$ respec --src http://localhost:8080/spec/index.html --out index.html
+```
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Specification 'lws-ucs'
 
 This is the repository for lws-ucs. You're welcome to contribute! Let's make the Web rock our socks
@@ -13,35 +12,3 @@ LWS user stories are classified under the following categories:
 * Technical: related to infrastructure tasks (e.g., "As a Service Provider, I want the ability to archive LWS storages").
 * Spike: used to explore or research an unknown aspect of the project (e.g., "Research what Identity System supports delegation.").
 
-## How to build this spec
-
-This repository uses the [ReSpec toolchain](https://respec.org/docs/). Please find below a quick getting started cheatsheet using the [command line](https://respec.org/docs/#using-command-line) tools.
-
-Setup `respec` for multiple use:
-```
-$ npm install --global respec
-```
-Update your environment with the following variables:
-```
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
-export PUPPETEER_EXECUTABLE_PATH="/usr/bin/google-chrome"
-# replace "/usr/bin/google-chrome" with path to Chrome executable on your system.
-# On MacOS, it's generally:
-# "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-```
-This spec uses the `data-include` attribute. For `respec` to work locally, the content MUST be served by a web server. One easy way to achive that is to run one from the project directory:
-```
-# Install a local HTTP server if not already installed (one time)
-$ npm install -g http-server
-
-# Start the server in your project directory
-$ http-server
-Starting up http-server, serving ./
-
-http-server version: 14.1.1
-```
-
-Note that the server starts on port 8080. Now you can run `respec` to generate the spec [`index.html`](http://localhost:8080/index.html) in the project root and test changes.
-```
-$ respec --src http://localhost:8080/spec/index.html --out index.html
-```

--- a/spec/index.html
+++ b/spec/index.html
@@ -10,6 +10,7 @@
         specStatus: "ED",
         shortName: "lws-ucs",
         copyrightStart:  "2024",
+        github: "w3c/lws-ucs",
         // previousPublishDate:  "N/A",
         editors: [
           { name: "Pierre-Antoine Champin" },


### PR DESCRIPTION
Move build instructions out of README per [request from previous PR #10](https://github.com/w3c/lws-ucs/pull/20#discussion_r1871136588).