### PR TITLE
add minimal CSS for readable tables

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -34,6 +34,15 @@
         },
       };
     </script>
+    <style>
+      table {
+        border-collapse: collapse;
+      }
+      table th, table td {
+        border: thin solid black;
+        padding: 0 0.2em;
+      }
+    </style>
   </head>
   <body>
     <section id="abstract">


### PR DESCRIPTION
with this, all tables (either HTML or Markdown) will be acceptably readable


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/pull/139.html" title="Last updated on Mar 17, 2025, 3:16 PM UTC (67f4ff6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/139/1175f20...67f4ff6.html" title="Last updated on Mar 17, 2025, 3:16 PM UTC (67f4ff6)">Diff</a>