### PR TITLE
import use-cases from github

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -65,6 +65,7 @@
       <h2>Use Cases</h2>
       <p>The use cases for this specification are documented below.</p>
       <div data-include="user-stories.md" data-include-format="markdown" data-include-replace="true"></div>
+      <div data-include="pending_usecases.md" data-include-format="markdown" data-include-replace="true"></div>
     </section>
     <section id="requirements">
       <h2>Requirements</h2>

--- a/spec/pending_usecases.md
+++ b/spec/pending_usecases.md
@@ -1,0 +1,692 @@
+
+<section data-max-toc="2">
+<h2>Pending use cases</h2>
+
+The following use-cases are pending triage into one of the previous sections.
+
+
+<section id="uc2">
+<h3>Repository for personal information management, with format conversion</h3>
+<div class=issue data-number=2></div>
+</section>
+
+
+<section id="uc3">
+<h3>Meeting scheduling, with offline and 3rd person</h3>
+<div class=issue data-number=3></div>
+</section>
+
+
+<section id="uc4">
+<h3>Encrypted linked data, with optional decryption and sharing</h3>
+<div class=issue data-number=4></div>
+</section>
+
+
+<section id="uc6">
+<h3>Timeseries data</h3>
+<div class=issue data-number=6></div>
+</section>
+
+
+<section id="uc7">
+<h3>Authoring Tool for Collaborative Web Content Creation</h3>
+<div class=issue data-number=7></div>
+</section>
+
+
+<section id="uc8">
+<h3>Granularities in sharing sensor data</h3>
+<div class=issue data-number=8></div>
+</section>
+
+
+<section id="uc9">
+<h3>Legal reporting obligations in data exchanges</h3>
+<div class=issue data-number=9></div>
+</section>
+
+
+<section id="uc10">
+<h3>Administrative assistant working for department head</h3>
+<div class=issue data-number=10></div>
+</section>
+
+
+<section id="uc11">
+<h3>Access to stored health records</h3>
+<div class=issue data-number=11></div>
+</section>
+
+
+<section id="uc12">
+<h3>bring-your-own-data web apps</h3>
+<div class=issue data-number=12></div>
+</section>
+
+
+<section id="uc13">
+<h3>bring-your-own-data native apps</h3>
+<div class=issue data-number=13></div>
+</section>
+
+
+<section id="uc14">
+<h3>An asynchronous digital goods delivery</h3>
+<div class=issue data-number=14></div>
+</section>
+
+
+<section id="uc15">
+<h3>Community-based sharing app <DRAFT></h3>
+<div class=issue data-number=15></div>
+</section>
+
+
+<section id="uc17">
+<h3>Context aware access policies</h3>
+<div class=issue data-number=17></div>
+</section>
+
+
+<section id="uc18">
+<h3>Large and/or resumable HTTP uploads</h3>
+<div class=issue data-number=18></div>
+</section>
+
+
+<section id="uc21">
+<h3>Server / Storage Description</h3>
+<div class=issue data-number=21></div>
+</section>
+
+
+<section id="uc22">
+<h3>Invitation</h3>
+<div class=issue data-number=22></div>
+</section>
+
+
+<section id="uc24">
+<h3>DECOUPLING between API PROTOCOL(s) and INTEROP specs</h3>
+<div class=issue data-number=24></div>
+</section>
+
+
+<section id="uc25">
+<h3>Identity and Credentials Management</h3>
+<div class=issue data-number=25></div>
+</section>
+
+
+<section id="uc26">
+<h3>Combining data from multiple sources</h3>
+<div class=issue data-number=26></div>
+</section>
+
+
+<section id="uc27">
+<h3>Grant access to (business) data</h3>
+<div class=issue data-number=27></div>
+</section>
+
+
+<section id="uc28">
+<h3>Requesting access to (business) data</h3>
+<div class=issue data-number=28></div>
+</section>
+
+
+<section id="uc29">
+<h3>Sovereign decision which identity provider, applications, and users to trust</h3>
+<div class=issue data-number=29></div>
+</section>
+
+
+<section id="uc30">
+<h3>Move between service providers</h3>
+<div class=issue data-number=30></div>
+</section>
+
+
+<section id="uc31">
+<h3>Personal website</h3>
+<div class=issue data-number=31></div>
+</section>
+
+
+<section id="uc32">
+<h3>Update Notifications</h3>
+<div class=issue data-number=32></div>
+</section>
+
+
+<section id="uc33">
+<h3>Authoring Arbitrary Hypermedia</h3>
+<div class=issue data-number=33></div>
+</section>
+
+
+<section id="uc34">
+<h3>Error Messages</h3>
+<div class=issue data-number=34></div>
+</section>
+
+
+<section id="uc35">
+<h3>Sharing Access</h3>
+<div class=issue data-number=35></div>
+</section>
+
+
+<section id="uc37">
+<h3>Data owner can setup an online storage for data</h3>
+<div class=issue data-number=37></div>
+</section>
+
+
+<section id="uc38">
+<h3>Group/organization MUST be able to be a data owner</h3>
+<div class=issue data-number=38></div>
+</section>
+
+
+<section id="uc39">
+<h3>Server Side authentication and Data Access</h3>
+<div class=issue data-number=39></div>
+</section>
+
+
+<section id="uc40">
+<h3>Integration of existing backend services</h3>
+<div class=issue data-number=40></div>
+</section>
+
+
+<section id="uc41">
+<h3>Silent Authentication</h3>
+<div class=issue data-number=41></div>
+</section>
+
+
+<section id="uc42">
+<h3>Scheduling</h3>
+<div class=issue data-number=42></div>
+</section>
+
+
+<section id="uc43">
+<h3>End-user ownership of storage at service providers</h3>
+<div class=issue data-number=43></div>
+</section>
+
+
+<section id="uc44">
+<h3>End-to-end encryption (in/out data transfer and storage)</h3>
+<div class=issue data-number=44></div>
+</section>
+
+
+<section id="uc45">
+<h3>SPARQL queries</h3>
+<div class=issue data-number=45></div>
+</section>
+
+
+<section id="uc46">
+<h3>Data integration across medical, fitness, dietary, medication data</h3>
+<div class=issue data-number=46></div>
+</section>
+
+
+<section id="uc47">
+<h3>Automatic load of a DataBrowser when client is non-data browser</h3>
+<div class=issue data-number=47></div>
+</section>
+
+
+<section id="uc48">
+<h3>WebId profile case - Load of a DataBrowser when client is browser </h3>
+<div class=issue data-number=48></div>
+</section>
+
+
+<section id="uc49">
+<h3>Log back into applications without re-directing to IDP Provider</h3>
+<div class=issue data-number=49></div>
+</section>
+
+
+<section id="uc50">
+<h3>Browser-level Log In</h3>
+<div class=issue data-number=50></div>
+</section>
+
+
+<section id="uc51">
+<h3>Passkey / WebAuthn Login</h3>
+<div class=issue data-number=51></div>
+</section>
+
+
+<section id="uc52">
+<h3>Home monitoring for elderly </h3>
+<div class=issue data-number=52></div>
+</section>
+
+
+<section id="uc53">
+<h3>Data integration for building management and building dweller comfort</h3>
+<div class=issue data-number=53></div>
+</section>
+
+
+<section id="uc54">
+<h3>Patient monitoring for bariatric surgery </h3>
+<div class=issue data-number=54></div>
+</section>
+
+
+<section id="uc55">
+<h3>Contextual Interactions via Native User Agent or Add-on</h3>
+<div class=issue data-number=55></div>
+</section>
+
+
+<section id="uc56">
+<h3>Proxy</h3>
+<div class=issue data-number=56></div>
+</section>
+
+
+<section id="uc57">
+<h3>Custom resource rendering when visiting URI using browser</h3>
+<div class=issue data-number=57></div>
+</section>
+
+
+<section id="uc58">
+<h3>Fallback/Alternative (storage) service provider / location</h3>
+<div class=issue data-number=58></div>
+</section>
+
+
+<section id="uc59">
+<h3>Usage Control</h3>
+<div class=issue data-number=59></div>
+</section>
+
+
+<section id="uc60">
+<h3>Freedom of policy modelling language/mechanism</h3>
+<div class=issue data-number=60></div>
+</section>
+
+
+<section id="uc61">
+<h3>Intuitive (Data Type-Based) Policy Management</h3>
+<div class=issue data-number=61></div>
+</section>
+
+
+<section id="uc62">
+<h3>Interface-Based Policy Management</h3>
+<div class=issue data-number=62></div>
+</section>
+
+
+<section id="uc63">
+<h3>Policy Management for Derived Resources</h3>
+<div class=issue data-number=63></div>
+</section>
+
+
+<section id="uc64">
+<h3>Fine-Grained Control Over Resource Access</h3>
+<div class=issue data-number=64></div>
+</section>
+
+
+<section id="uc65">
+<h3>Context-based Access and Usage Control</h3>
+<div class=issue data-number=65></div>
+</section>
+
+
+<section id="uc66">
+<h3>Purpose-based Access and Usage Control</h3>
+<div class=issue data-number=66></div>
+</section>
+
+
+<section id="uc67">
+<h3>Processing-based Access and Usage Control</h3>
+<div class=issue data-number=67></div>
+</section>
+
+
+<section id="uc68">
+<h3>Verifying authorization claims <DRAFT></h3>
+<div class=issue data-number=68></div>
+</section>
+
+
+<section id="uc69">
+<h3>Keep policies secret</h3>
+<div class=issue data-number=69></div>
+</section>
+
+
+<section id="uc70">
+<h3>Discoverable Authorization Requirements <DRAFT></h3>
+<div class=issue data-number=70></div>
+</section>
+
+
+<section id="uc71">
+<h3>Broad Credential Compatibility <DRAFT></h3>
+<div class=issue data-number=71></div>
+</section>
+
+
+<section id="uc72">
+<h3>Performant Access and Usage Control <DRAFT></h3>
+<div class=issue data-number=72></div>
+</section>
+
+
+<section id="uc73">
+<h3>Policy Overview <DRAFT></h3>
+<div class=issue data-number=73></div>
+</section>
+
+
+<section id="uc74">
+<h3>Understandable Policy Management <DRAFT></h3>
+<div class=issue data-number=74></div>
+</section>
+
+
+<section id="uc75">
+<h3>Intelligent Access Control for Subsets/Supersets <DRAFT></h3>
+<div class=issue data-number=75></div>
+</section>
+
+
+<section id="uc76">
+<h3>Aggregated Authorization over Multiple Storage Locations <DRAFT> </h3>
+<div class=issue data-number=76></div>
+</section>
+
+
+<section id="uc77">
+<h3>Transferability of Policies <DRAFT></h3>
+<div class=issue data-number=77></div>
+</section>
+
+
+<section id="uc78">
+<h3>Notification of Access Requests <DRAFT></h3>
+<div class=issue data-number=78></div>
+</section>
+
+
+<section id="uc79">
+<h3>Poll/Push Callback upon Addressed Access Request <DRAFT></h3>
+<div class=issue data-number=79></div>
+</section>
+
+
+<section id="uc80">
+<h3>Support for Different Legal Grounds</h3>
+<div class=issue data-number=80></div>
+</section>
+
+
+<section id="uc81">
+<h3>(Micro-)Contract-based Compensation for Access</h3>
+<div class=issue data-number=81></div>
+</section>
+
+
+<section id="uc82">
+<h3>Automated Access and Usage Control</h3>
+<div class=issue data-number=82></div>
+</section>
+
+
+<section id="uc83">
+<h3>Proof of Provenance</h3>
+<div class=issue data-number=83></div>
+</section>
+
+
+<section id="uc84">
+<h3>Overview/Log of Resource Access (Behaviour)</h3>
+<div class=issue data-number=84></div>
+</section>
+
+
+<section id="uc85">
+<h3>Auditable Proof/Receipt of Authorization</h3>
+<div class=issue data-number=85></div>
+</section>
+
+
+<section id="uc86">
+<h3>Explainable Policy Engine Decisions</h3>
+<div class=issue data-number=86></div>
+</section>
+
+
+<section id="uc87">
+<h3>Resource Discoverability</h3>
+<div class=issue data-number=87></div>
+</section>
+
+
+<section id="uc88">
+<h3>Resource Aggregation</h3>
+<div class=issue data-number=88></div>
+</section>
+
+
+<section id="uc89">
+<h3>Share data with a (potentially large) community/group of people</h3>
+<div class=issue data-number=89></div>
+</section>
+
+
+<section id="uc90">
+<h3>Identity attestation</h3>
+<div class=issue data-number=90></div>
+</section>
+
+
+<section id="uc92">
+<h3>Access verification for external services</h3>
+<div class=issue data-number=92></div>
+</section>
+
+
+<section id="uc93">
+<h3>Custom validation of requests that mutate data</h3>
+<div class=issue data-number=93></div>
+</section>
+
+
+<section id="uc94">
+<h3>Custom metadata and/or HTTP header</h3>
+<div class=issue data-number=94></div>
+</section>
+
+
+<section id="uc95">
+<h3>Multiple profiles management</h3>
+<div class=issue data-number=95></div>
+</section>
+
+
+<section id="uc96">
+<h3>Offline Support / Local-First</h3>
+<div class=issue data-number=96></div>
+</section>
+
+
+<section id="uc97">
+<h3>Filesystem-like simple data storage and browsing</h3>
+<div class=issue data-number=97></div>
+</section>
+
+
+<section id="uc98">
+<h3>Knowledge-graph-style data storage and browsing</h3>
+<div class=issue data-number=98></div>
+</section>
+
+
+<section id="uc99">
+<h3>Universal communication channel</h3>
+<div class=issue data-number=99></div>
+</section>
+
+
+<section id="uc100">
+<h3>Application notifications (email or web push)</h3>
+<div class=issue data-number=100></div>
+</section>
+
+
+<section id="uc101">
+<h3>Applications storage listening</h3>
+<div class=issue data-number=101></div>
+</section>
+
+
+<section id="uc102">
+<h3>Membership and roles management</h3>
+<div class=issue data-number=102></div>
+</section>
+
+
+<section id="uc103">
+<h3>Pagination, filtering and ordering</h3>
+<div class=issue data-number=103></div>
+</section>
+
+
+<section id="uc104">
+<h3>Access delegation by autonomous groups/organizations</h3>
+<div class=issue data-number=104></div>
+</section>
+
+
+<section id="uc105">
+<h3>Access solid data stored in home desktop or home-NAS </h3>
+<div class=issue data-number=105></div>
+</section>
+
+
+<section id="uc106">
+<h3>Projection- / View-based filesystem-like storage and access</h3>
+<div class=issue data-number=106></div>
+</section>
+
+
+<section id="uc107">
+<h3>General purpose data storage</h3>
+<div class=issue data-number=107></div>
+</section>
+
+
+<section id="uc108">
+<h3>Uniquely identify storage globally</h3>
+<div class=issue data-number=108></div>
+</section>
+
+
+<section id="uc109">
+<h3>One-to-many relationship between owning entity and storage(s)</h3>
+<div class=issue data-number=109></div>
+</section>
+
+
+<section id="uc110">
+<h3>Ability to split or aggregate storages</h3>
+<div class=issue data-number=110></div>
+</section>
+
+
+<section id="uc111">
+<h3>Storage hosting</h3>
+<div class=issue data-number=111></div>
+</section>
+
+
+<section id="uc113">
+<h3>Basic data sharing</h3>
+<div class=issue data-number=113></div>
+</section>
+
+
+<section id="uc114">
+<h3>Entity Authentication</h3>
+<div class=issue data-number=114></div>
+</section>
+
+
+<section id="uc115">
+<h3>Entity globally unique identity</h3>
+<div class=issue data-number=115></div>
+</section>
+
+
+<section id="uc116">
+<h3>Selective access to data</h3>
+<div class=issue data-number=116></div>
+</section>
+
+
+<section id="uc118">
+<h3>Access delegation</h3>
+<div class=issue data-number=118></div>
+</section>
+
+
+<section id="uc120">
+<h3>Non-owner can use an app of their choice to access data shared with them</h3>
+<div class=issue data-number=120></div>
+</section>
+
+
+<section id="uc138">
+<h3>Verify imported data</h3>
+<div class=issue data-number=138></div>
+</section>
+
+
+<section id="uc144">
+<h3>Polling App</h3>
+<div class=issue data-number=144></div>
+</section>
+
+
+<section id="uc146">
+<h3>Semantic Collaboration</h3>
+<div class=issue data-number=146></div>
+</section>
+
+
+<section id="uc147">
+<h3>Restricting client access to sensitive data</h3>
+<div class=issue data-number=147></div>
+</section>
+
+
+<section id="uc148">
+<h3>Triple Level Resource (State)</h3>
+<div class=issue data-number=148></div>
+</section>
+
+
+</section>

--- a/spec/pending_usecases.md
+++ b/spec/pending_usecases.md
@@ -5,685 +5,685 @@
 The following use-cases are pending triage into one of the previous sections.
 
 
-<section id="uc2">
+<section id="uc-2">
 <h3>Repository for personal information management, with format conversion</h3>
 <div class=issue data-number=2></div>
 </section>
 
 
-<section id="uc3">
+<section id="uc-3">
 <h3>Meeting scheduling, with offline and 3rd person</h3>
 <div class=issue data-number=3></div>
 </section>
 
 
-<section id="uc4">
+<section id="uc-4">
 <h3>Encrypted linked data, with optional decryption and sharing</h3>
 <div class=issue data-number=4></div>
 </section>
 
 
-<section id="uc6">
+<section id="uc-6">
 <h3>Timeseries data</h3>
 <div class=issue data-number=6></div>
 </section>
 
 
-<section id="uc7">
+<section id="uc-7">
 <h3>Authoring Tool for Collaborative Web Content Creation</h3>
 <div class=issue data-number=7></div>
 </section>
 
 
-<section id="uc8">
+<section id="uc-8">
 <h3>Granularities in sharing sensor data</h3>
 <div class=issue data-number=8></div>
 </section>
 
 
-<section id="uc9">
+<section id="uc-9">
 <h3>Legal reporting obligations in data exchanges</h3>
 <div class=issue data-number=9></div>
 </section>
 
 
-<section id="uc10">
+<section id="uc-10">
 <h3>Administrative assistant working for department head</h3>
 <div class=issue data-number=10></div>
 </section>
 
 
-<section id="uc11">
+<section id="uc-11">
 <h3>Access to stored health records</h3>
 <div class=issue data-number=11></div>
 </section>
 
 
-<section id="uc12">
+<section id="uc-12">
 <h3>bring-your-own-data web apps</h3>
 <div class=issue data-number=12></div>
 </section>
 
 
-<section id="uc13">
+<section id="uc-13">
 <h3>bring-your-own-data native apps</h3>
 <div class=issue data-number=13></div>
 </section>
 
 
-<section id="uc14">
+<section id="uc-14">
 <h3>An asynchronous digital goods delivery</h3>
 <div class=issue data-number=14></div>
 </section>
 
 
-<section id="uc15">
+<section id="uc-15">
 <h3>Community-based sharing app <DRAFT></h3>
 <div class=issue data-number=15></div>
 </section>
 
 
-<section id="uc17">
+<section id="uc-17">
 <h3>Context aware access policies</h3>
 <div class=issue data-number=17></div>
 </section>
 
 
-<section id="uc18">
+<section id="uc-18">
 <h3>Large and/or resumable HTTP uploads</h3>
 <div class=issue data-number=18></div>
 </section>
 
 
-<section id="uc21">
+<section id="uc-21">
 <h3>Server / Storage Description</h3>
 <div class=issue data-number=21></div>
 </section>
 
 
-<section id="uc22">
+<section id="uc-22">
 <h3>Invitation</h3>
 <div class=issue data-number=22></div>
 </section>
 
 
-<section id="uc24">
+<section id="uc-24">
 <h3>DECOUPLING between API PROTOCOL(s) and INTEROP specs</h3>
 <div class=issue data-number=24></div>
 </section>
 
 
-<section id="uc25">
+<section id="uc-25">
 <h3>Identity and Credentials Management</h3>
 <div class=issue data-number=25></div>
 </section>
 
 
-<section id="uc26">
+<section id="uc-26">
 <h3>Combining data from multiple sources</h3>
 <div class=issue data-number=26></div>
 </section>
 
 
-<section id="uc27">
+<section id="uc-27">
 <h3>Grant access to (business) data</h3>
 <div class=issue data-number=27></div>
 </section>
 
 
-<section id="uc28">
+<section id="uc-28">
 <h3>Requesting access to (business) data</h3>
 <div class=issue data-number=28></div>
 </section>
 
 
-<section id="uc29">
+<section id="uc-29">
 <h3>Sovereign decision which identity provider, applications, and users to trust</h3>
 <div class=issue data-number=29></div>
 </section>
 
 
-<section id="uc30">
+<section id="uc-30">
 <h3>Move between service providers</h3>
 <div class=issue data-number=30></div>
 </section>
 
 
-<section id="uc31">
+<section id="uc-31">
 <h3>Personal website</h3>
 <div class=issue data-number=31></div>
 </section>
 
 
-<section id="uc32">
+<section id="uc-32">
 <h3>Update Notifications</h3>
 <div class=issue data-number=32></div>
 </section>
 
 
-<section id="uc33">
+<section id="uc-33">
 <h3>Authoring Arbitrary Hypermedia</h3>
 <div class=issue data-number=33></div>
 </section>
 
 
-<section id="uc34">
+<section id="uc-34">
 <h3>Error Messages</h3>
 <div class=issue data-number=34></div>
 </section>
 
 
-<section id="uc35">
+<section id="uc-35">
 <h3>Sharing Access</h3>
 <div class=issue data-number=35></div>
 </section>
 
 
-<section id="uc37">
+<section id="uc-37">
 <h3>Data owner can setup an online storage for data</h3>
 <div class=issue data-number=37></div>
 </section>
 
 
-<section id="uc38">
+<section id="uc-38">
 <h3>Group/organization MUST be able to be a data owner</h3>
 <div class=issue data-number=38></div>
 </section>
 
 
-<section id="uc39">
+<section id="uc-39">
 <h3>Server Side authentication and Data Access</h3>
 <div class=issue data-number=39></div>
 </section>
 
 
-<section id="uc40">
+<section id="uc-40">
 <h3>Integration of existing backend services</h3>
 <div class=issue data-number=40></div>
 </section>
 
 
-<section id="uc41">
+<section id="uc-41">
 <h3>Silent Authentication</h3>
 <div class=issue data-number=41></div>
 </section>
 
 
-<section id="uc42">
+<section id="uc-42">
 <h3>Scheduling</h3>
 <div class=issue data-number=42></div>
 </section>
 
 
-<section id="uc43">
+<section id="uc-43">
 <h3>End-user ownership of storage at service providers</h3>
 <div class=issue data-number=43></div>
 </section>
 
 
-<section id="uc44">
+<section id="uc-44">
 <h3>End-to-end encryption (in/out data transfer and storage)</h3>
 <div class=issue data-number=44></div>
 </section>
 
 
-<section id="uc45">
+<section id="uc-45">
 <h3>SPARQL queries</h3>
 <div class=issue data-number=45></div>
 </section>
 
 
-<section id="uc46">
+<section id="uc-46">
 <h3>Data integration across medical, fitness, dietary, medication data</h3>
 <div class=issue data-number=46></div>
 </section>
 
 
-<section id="uc47">
+<section id="uc-47">
 <h3>Automatic load of a DataBrowser when client is non-data browser</h3>
 <div class=issue data-number=47></div>
 </section>
 
 
-<section id="uc48">
+<section id="uc-48">
 <h3>WebId profile case - Load of a DataBrowser when client is browser </h3>
 <div class=issue data-number=48></div>
 </section>
 
 
-<section id="uc49">
+<section id="uc-49">
 <h3>Log back into applications without re-directing to IDP Provider</h3>
 <div class=issue data-number=49></div>
 </section>
 
 
-<section id="uc50">
+<section id="uc-50">
 <h3>Browser-level Log In</h3>
 <div class=issue data-number=50></div>
 </section>
 
 
-<section id="uc51">
+<section id="uc-51">
 <h3>Passkey / WebAuthn Login</h3>
 <div class=issue data-number=51></div>
 </section>
 
 
-<section id="uc52">
+<section id="uc-52">
 <h3>Home monitoring for elderly </h3>
 <div class=issue data-number=52></div>
 </section>
 
 
-<section id="uc53">
+<section id="uc-53">
 <h3>Data integration for building management and building dweller comfort</h3>
 <div class=issue data-number=53></div>
 </section>
 
 
-<section id="uc54">
+<section id="uc-54">
 <h3>Patient monitoring for bariatric surgery </h3>
 <div class=issue data-number=54></div>
 </section>
 
 
-<section id="uc55">
+<section id="uc-55">
 <h3>Contextual Interactions via Native User Agent or Add-on</h3>
 <div class=issue data-number=55></div>
 </section>
 
 
-<section id="uc56">
+<section id="uc-56">
 <h3>Proxy</h3>
 <div class=issue data-number=56></div>
 </section>
 
 
-<section id="uc57">
+<section id="uc-57">
 <h3>Custom resource rendering when visiting URI using browser</h3>
 <div class=issue data-number=57></div>
 </section>
 
 
-<section id="uc58">
+<section id="uc-58">
 <h3>Fallback/Alternative (storage) service provider / location</h3>
 <div class=issue data-number=58></div>
 </section>
 
 
-<section id="uc59">
+<section id="uc-59">
 <h3>Usage Control</h3>
 <div class=issue data-number=59></div>
 </section>
 
 
-<section id="uc60">
+<section id="uc-60">
 <h3>Freedom of policy modelling language/mechanism</h3>
 <div class=issue data-number=60></div>
 </section>
 
 
-<section id="uc61">
+<section id="uc-61">
 <h3>Intuitive (Data Type-Based) Policy Management</h3>
 <div class=issue data-number=61></div>
 </section>
 
 
-<section id="uc62">
+<section id="uc-62">
 <h3>Interface-Based Policy Management</h3>
 <div class=issue data-number=62></div>
 </section>
 
 
-<section id="uc63">
+<section id="uc-63">
 <h3>Policy Management for Derived Resources</h3>
 <div class=issue data-number=63></div>
 </section>
 
 
-<section id="uc64">
+<section id="uc-64">
 <h3>Fine-Grained Control Over Resource Access</h3>
 <div class=issue data-number=64></div>
 </section>
 
 
-<section id="uc65">
+<section id="uc-65">
 <h3>Context-based Access and Usage Control</h3>
 <div class=issue data-number=65></div>
 </section>
 
 
-<section id="uc66">
+<section id="uc-66">
 <h3>Purpose-based Access and Usage Control</h3>
 <div class=issue data-number=66></div>
 </section>
 
 
-<section id="uc67">
+<section id="uc-67">
 <h3>Processing-based Access and Usage Control</h3>
 <div class=issue data-number=67></div>
 </section>
 
 
-<section id="uc68">
+<section id="uc-68">
 <h3>Verifying authorization claims <DRAFT></h3>
 <div class=issue data-number=68></div>
 </section>
 
 
-<section id="uc69">
+<section id="uc-69">
 <h3>Keep policies secret</h3>
 <div class=issue data-number=69></div>
 </section>
 
 
-<section id="uc70">
+<section id="uc-70">
 <h3>Discoverable Authorization Requirements <DRAFT></h3>
 <div class=issue data-number=70></div>
 </section>
 
 
-<section id="uc71">
+<section id="uc-71">
 <h3>Broad Credential Compatibility <DRAFT></h3>
 <div class=issue data-number=71></div>
 </section>
 
 
-<section id="uc72">
+<section id="uc-72">
 <h3>Performant Access and Usage Control <DRAFT></h3>
 <div class=issue data-number=72></div>
 </section>
 
 
-<section id="uc73">
+<section id="uc-73">
 <h3>Policy Overview <DRAFT></h3>
 <div class=issue data-number=73></div>
 </section>
 
 
-<section id="uc74">
+<section id="uc-74">
 <h3>Understandable Policy Management <DRAFT></h3>
 <div class=issue data-number=74></div>
 </section>
 
 
-<section id="uc75">
+<section id="uc-75">
 <h3>Intelligent Access Control for Subsets/Supersets <DRAFT></h3>
 <div class=issue data-number=75></div>
 </section>
 
 
-<section id="uc76">
+<section id="uc-76">
 <h3>Aggregated Authorization over Multiple Storage Locations <DRAFT> </h3>
 <div class=issue data-number=76></div>
 </section>
 
 
-<section id="uc77">
+<section id="uc-77">
 <h3>Transferability of Policies <DRAFT></h3>
 <div class=issue data-number=77></div>
 </section>
 
 
-<section id="uc78">
+<section id="uc-78">
 <h3>Notification of Access Requests <DRAFT></h3>
 <div class=issue data-number=78></div>
 </section>
 
 
-<section id="uc79">
+<section id="uc-79">
 <h3>Poll/Push Callback upon Addressed Access Request <DRAFT></h3>
 <div class=issue data-number=79></div>
 </section>
 
 
-<section id="uc80">
+<section id="uc-80">
 <h3>Support for Different Legal Grounds</h3>
 <div class=issue data-number=80></div>
 </section>
 
 
-<section id="uc81">
+<section id="uc-81">
 <h3>(Micro-)Contract-based Compensation for Access</h3>
 <div class=issue data-number=81></div>
 </section>
 
 
-<section id="uc82">
+<section id="uc-82">
 <h3>Automated Access and Usage Control</h3>
 <div class=issue data-number=82></div>
 </section>
 
 
-<section id="uc83">
+<section id="uc-83">
 <h3>Proof of Provenance</h3>
 <div class=issue data-number=83></div>
 </section>
 
 
-<section id="uc84">
+<section id="uc-84">
 <h3>Overview/Log of Resource Access (Behaviour)</h3>
 <div class=issue data-number=84></div>
 </section>
 
 
-<section id="uc85">
+<section id="uc-85">
 <h3>Auditable Proof/Receipt of Authorization</h3>
 <div class=issue data-number=85></div>
 </section>
 
 
-<section id="uc86">
+<section id="uc-86">
 <h3>Explainable Policy Engine Decisions</h3>
 <div class=issue data-number=86></div>
 </section>
 
 
-<section id="uc87">
+<section id="uc-87">
 <h3>Resource Discoverability</h3>
 <div class=issue data-number=87></div>
 </section>
 
 
-<section id="uc88">
+<section id="uc-88">
 <h3>Resource Aggregation</h3>
 <div class=issue data-number=88></div>
 </section>
 
 
-<section id="uc89">
+<section id="uc-89">
 <h3>Share data with a (potentially large) community/group of people</h3>
 <div class=issue data-number=89></div>
 </section>
 
 
-<section id="uc90">
+<section id="uc-90">
 <h3>Identity attestation</h3>
 <div class=issue data-number=90></div>
 </section>
 
 
-<section id="uc92">
+<section id="uc-92">
 <h3>Access verification for external services</h3>
 <div class=issue data-number=92></div>
 </section>
 
 
-<section id="uc93">
+<section id="uc-93">
 <h3>Custom validation of requests that mutate data</h3>
 <div class=issue data-number=93></div>
 </section>
 
 
-<section id="uc94">
+<section id="uc-94">
 <h3>Custom metadata and/or HTTP header</h3>
 <div class=issue data-number=94></div>
 </section>
 
 
-<section id="uc95">
+<section id="uc-95">
 <h3>Multiple profiles management</h3>
 <div class=issue data-number=95></div>
 </section>
 
 
-<section id="uc96">
+<section id="uc-96">
 <h3>Offline Support / Local-First</h3>
 <div class=issue data-number=96></div>
 </section>
 
 
-<section id="uc97">
+<section id="uc-97">
 <h3>Filesystem-like simple data storage and browsing</h3>
 <div class=issue data-number=97></div>
 </section>
 
 
-<section id="uc98">
+<section id="uc-98">
 <h3>Knowledge-graph-style data storage and browsing</h3>
 <div class=issue data-number=98></div>
 </section>
 
 
-<section id="uc99">
+<section id="uc-99">
 <h3>Universal communication channel</h3>
 <div class=issue data-number=99></div>
 </section>
 
 
-<section id="uc100">
+<section id="uc-100">
 <h3>Application notifications (email or web push)</h3>
 <div class=issue data-number=100></div>
 </section>
 
 
-<section id="uc101">
+<section id="uc-101">
 <h3>Applications storage listening</h3>
 <div class=issue data-number=101></div>
 </section>
 
 
-<section id="uc102">
+<section id="uc-102">
 <h3>Membership and roles management</h3>
 <div class=issue data-number=102></div>
 </section>
 
 
-<section id="uc103">
+<section id="uc-103">
 <h3>Pagination, filtering and ordering</h3>
 <div class=issue data-number=103></div>
 </section>
 
 
-<section id="uc104">
+<section id="uc-104">
 <h3>Access delegation by autonomous groups/organizations</h3>
 <div class=issue data-number=104></div>
 </section>
 
 
-<section id="uc105">
+<section id="uc-105">
 <h3>Access solid data stored in home desktop or home-NAS </h3>
 <div class=issue data-number=105></div>
 </section>
 
 
-<section id="uc106">
+<section id="uc-106">
 <h3>Projection- / View-based filesystem-like storage and access</h3>
 <div class=issue data-number=106></div>
 </section>
 
 
-<section id="uc107">
+<section id="uc-107">
 <h3>General purpose data storage</h3>
 <div class=issue data-number=107></div>
 </section>
 
 
-<section id="uc108">
+<section id="uc-108">
 <h3>Uniquely identify storage globally</h3>
 <div class=issue data-number=108></div>
 </section>
 
 
-<section id="uc109">
+<section id="uc-109">
 <h3>One-to-many relationship between owning entity and storage(s)</h3>
 <div class=issue data-number=109></div>
 </section>
 
 
-<section id="uc110">
+<section id="uc-110">
 <h3>Ability to split or aggregate storages</h3>
 <div class=issue data-number=110></div>
 </section>
 
 
-<section id="uc111">
+<section id="uc-111">
 <h3>Storage hosting</h3>
 <div class=issue data-number=111></div>
 </section>
 
 
-<section id="uc113">
+<section id="uc-113">
 <h3>Basic data sharing</h3>
 <div class=issue data-number=113></div>
 </section>
 
 
-<section id="uc114">
+<section id="uc-114">
 <h3>Entity Authentication</h3>
 <div class=issue data-number=114></div>
 </section>
 
 
-<section id="uc115">
+<section id="uc-115">
 <h3>Entity globally unique identity</h3>
 <div class=issue data-number=115></div>
 </section>
 
 
-<section id="uc116">
+<section id="uc-116">
 <h3>Selective access to data</h3>
 <div class=issue data-number=116></div>
 </section>
 
 
-<section id="uc118">
+<section id="uc-118">
 <h3>Access delegation</h3>
 <div class=issue data-number=118></div>
 </section>
 
 
-<section id="uc120">
+<section id="uc-120">
 <h3>Non-owner can use an app of their choice to access data shared with them</h3>
 <div class=issue data-number=120></div>
 </section>
 
 
-<section id="uc138">
+<section id="uc-138">
 <h3>Verify imported data</h3>
 <div class=issue data-number=138></div>
 </section>
 
 
-<section id="uc144">
+<section id="uc-144">
 <h3>Polling App</h3>
 <div class=issue data-number=144></div>
 </section>
 
 
-<section id="uc146">
+<section id="uc-146">
 <h3>Semantic Collaboration</h3>
 <div class=issue data-number=146></div>
 </section>
 
 
-<section id="uc147">
+<section id="uc-147">
 <h3>Restricting client access to sensitive data</h3>
 <div class=issue data-number=147></div>
 </section>
 
 
-<section id="uc148">
+<section id="uc-148">
 <h3>Triple Level Resource (State)</h3>
 <div class=issue data-number=148></div>
 </section>


### PR DESCRIPTION
the rationale of this PR is to seed the Use Case documents with what we have on github.

It is expected that the editors then
- move each use-case into the appropriate section (Functional, Non-Functional, ...)
- replace the `<div class="issue">` with the appopriate text (possibly reusing text from the github issue)

The id of each issue (uc{issue_number}) is expected to remain valid, so that people can start pointing at use-cases in the document. If two use-cases are merged as duplicate,
anchors (`<a name="uc{issue_number}">`) should be added in the appropriate section, to avoid breaking links.

----

For the record, the markdown file `spec\pending_usecases.md` was generated with the following command:
```sh
gh issue list --label usecase -L 1000 --search "sort:created-asc" --json title,number --template '
<section data-max-toc="2">
<h2>Pending use cases</h2>

The following use-cases are pending triage into one of the previous sections.

{{range .}}
<section id="uc{{.number}}">
<h3>{{.title}}</h3>
<div class=issue data-number={{.number}}></div>
</section>

{{end}}
</section>
' | sed 's/<h3>\[UC\] /<h3>/' >spec/pending_usecases.md
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/pull/150.html" title="Last updated on May 15, 2025, 12:12 PM UTC (f884c32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/150/8dc7bd5...f884c32.html" title="Last updated on May 15, 2025, 12:12 PM UTC (f884c32)">Diff</a>