### PR TITLE
Add a "real" title to the document

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Spec proposal</title>
+    <title>Linked Web Storage Use Cases</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class='remove'>
       // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec


### PR DESCRIPTION
I'm not fixed on this particular title, but it can't remain "Spec proposal" when we publish it :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/pull/155.html" title="Last updated on May 15, 2025, 12:06 PM UTC (0479301)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/155/d68c070...0479301.html" title="Last updated on May 15, 2025, 12:06 PM UTC (0479301)">Diff</a>