### PR TITLE
chore: remove network flexibility ucs

### DIFF
--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -186,11 +186,6 @@
     Issues: [#31](https://github.com/w3c/lws-ucs/issues/31)  
     Stories: Website Creation
 
-41. <dfn>Network Flexibility</dfn> — The protocol shall ensure Storages remain accessible from home or mobile environments with dynamic IPs or NAT, providing mechanisms (e.g., NAT traversal, DNS aliasing) so connectivity isn't impeded by changing network endpoints.
-
-    Issues: [#105](https://github.com/w3c/lws-ucs/issues/105), [#68](https://github.com/w3c/lws-ucs/issues/68)  
-    Stories: Home Access
-
 42. <dfn>Bring-Your-Own-Data Apps</dfn> — The protocol shall enable third-party applications to store, read, update, and delete their data within user-managed Storages, and to discover available Storage capabilities, so that users retain data ownership and sovereignty over app-generated content.
 
     Issues: [#12](https://github.com/w3c/lws-ucs/issues/12), [#120](https://github.com/w3c/lws-ucs/issues/120)  


### PR DESCRIPTION
Removes network flexibility UCS as discussed in last weeks WG call


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeswr/lws-ucs/pull/189.html" title="Last updated on Jul 21, 2025, 1:38 PM UTC (7be2a26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/189/e8144dd...jeswr:7be2a26.html" title="Last updated on Jul 21, 2025, 1:38 PM UTC (7be2a26)">Diff</a>