### PR TITLE
chore: remove uc31

### DIFF
--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -138,11 +138,6 @@
     Issues: [#110](https://github.com/w3c/lws-ucs/issues/110), [#136](https://github.com/w3c/lws-ucs/issues/136)  
     Stories: Storage Flexibility
 
-31. <dfn>Performance and Scalability</dfn> — The protocol and its implementations shall be designed for high performance at scale. Access control checks and data operations should incur minimal overhead, and the design should allow batching, caching, and distributed/clustered deployments to meet typical web performance needs.
-
-    Issues: [#72](https://github.com/w3c/lws-ucs/issues/72)  
-    Stories: Performant Access Control
-
 32. <dfn>Clear Error Messaging</dfn> — The protocol shall specify clear and standardized error messages for various failure conditions, including meaningful status codes and human-readable information indicating the cause and possible remediation.
 
     Issues: [#34](https://github.com/w3c/lws-ucs/issues/34)  


### PR DESCRIPTION
As discussed in [today's call](https://www.w3.org/2025/07/21-lws-minutes.html) this is a process requirement and slated to be removed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeswr/lws-ucs/pull/193.html" title="Last updated on Jul 28, 2025, 1:23 PM UTC (525c138)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/193/39edcf1...jeswr:525c138.html" title="Last updated on Jul 28, 2025, 1:23 PM UTC (525c138)">Diff</a>