### PR TITLE
chore: remove Clear Error Messaging use case (uc32)

### DIFF
--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -143,11 +143,6 @@
     Issues: [#72](https://github.com/w3c/lws-ucs/issues/72)  
     Stories: Performant Access Control
 
-32. <dfn>Clear Error Messaging</dfn> — The protocol shall specify clear and standardized error messages for various failure conditions, including meaningful status codes and human-readable information indicating the cause and possible remediation.
-
-    Issues: [#34](https://github.com/w3c/lws-ucs/issues/34)  
-    Stories: Clear Error Messages
-
 33. <dfn>Profile Management</dfn> — The protocol shall support Entities having multiple distinct Profiles (e.g., "work" vs. "personal"), each with its own identifiers, metadata namespaces and access-control rules, so that data can be selectively shared under different personas.  
     Stories: Profile Sharing
 


### PR DESCRIPTION
As discussed in [today's call](https://www.w3.org/2025/07/21-lws-minutes.html) this is a process requirement and slated to be removed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jeswr/lws-ucs/pull/194.html" title="Last updated on Jul 28, 2025, 1:30 PM UTC (136fa66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/194/f663316...jeswr:136fa66.html" title="Last updated on Jul 28, 2025, 1:30 PM UTC (136fa66)">Diff</a>