### PR TITLE
change title for req 28: protocol binding independence

### DIFF
--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -184,7 +184,7 @@
     Issues: [#129](https://github.com/w3c/lws-ucs/issues/129)  
     Stories: Trust Mechanism for Storage Providers
 
-28. <dfn>Protocol Binding Independence</dfn> — The core data access and identity interactions shall be defined abstractly, decoupled from any single transport or encoding. While HTTP(S) is expected, the protocol's semantics must be mappable to alternative transports (e.g., gRPC, GraphQL over WebSocket, local IPC) without changing its fundamental model.
+28. <dfn>Loose Coupling of Underlying Protocols</dfn> — The core data access and identity interactions shall be defined abstractly, decoupled from any single transport or encoding. While HTTP(S) is expected, the protocol's semantics must be mappable to alternative transports (e.g., gRPC, GraphQL over WebSocket, local IPC) without changing its fundamental model.
 
     Issues: [#24](https://github.com/w3c/lws-ucs/issues/24)  
     Stories: API Protocol Decoupling


### PR DESCRIPTION
changed to "Loose Coupling of Underlying Protocols"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ebremer/lws-ucs/pull/199.html" title="Last updated on Jul 28, 2025, 2:24 PM UTC (d764f15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lws-ucs/199/07c5b1b...ebremer:d764f15.html" title="Last updated on Jul 28, 2025, 2:24 PM UTC (d764f15)">Diff</a>